### PR TITLE
[Scenario E] Use php-fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Those are Lambda execution time (not HTTP response time because you would have t
 | D | PHP | 12ms | 6ms | [url](https://27nex4iys7.execute-api.us-east-2.amazonaws.com/Prod) |
 | D | Symfony | 26ms | 15ms | [url](https://elha5ztbse.execute-api.us-east-2.amazonaws.com/Prod) |
 | E | PHP | 5ms | 1.1ms |  |
-| E | Symfony | 27ms | 14ms |  |
+| E | Symfony | 25ms | 13ms |  |
 | F | PHP | 5ms | 1.6ms |  |
 | F | Symfony | 24ms | 16ms |  |
 | G | PHP | 10ms | 6ms | [url](https://52ndy2s1ah.execute-api.us-east-2.amazonaws.com/Prod) |

--- a/e/php/bootstrap
+++ b/e/php/bootstrap
@@ -15,8 +15,9 @@ $lambdaRuntimeApi = getenv('AWS_LAMBDA_RUNTIME_API');
 
 require __DIR__ . '/vendor/autoload.php';
 
-$socket = '/tmp/php-cgi.sock';
-$cgi = new Process("php-cgi -b {$socket} -c /opt/php.ini -d extension_dir=/opt/php/extensions");
+$socket = '/tmp/php-fpm.sock';
+$config =  __DIR__ .'/php-fpm.conf';
+$cgi = new Process("php-fpm --fpm-config {$config} -c /opt/php.ini -d extension_dir=/opt/php/extensions");
 $cgi->setTimeout(null);
 $cgi->start(function ($type, $output) {
     if ($type === Process::ERR) {
@@ -25,11 +26,12 @@ $cgi->start(function ($type, $output) {
     }
 });
 
+
 register_shutdown_function(function() use(&$cgi) {
     $cgi->stop();
 });
 
-$wait = 10000; // 10ms
+$wait = 5000; // 5ms
 $timeout = 5000000; // 5 secs
 $elapsed = 0;
 while (! file_exists($socket)) {

--- a/e/php/php-fpm.conf
+++ b/e/php/php-fpm.conf
@@ -1,0 +1,6 @@
+error_log = /tmp/php-fpm.log
+
+[default]
+pm = static
+pm.max_children = 1
+listen = /tmp/php-fpm.sock

--- a/e/php/template.yaml
+++ b/e/php/template.yaml
@@ -17,7 +17,7 @@ Resources:
             Handler: index.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416360873395:layer:php-72:3'
+                - 'arn:aws:lambda:us-east-2:416360873395:layer:php-72:4'
             Environment:
                 Variables:
                     APP_ENV: prod

--- a/e/symfony/bootstrap
+++ b/e/symfony/bootstrap
@@ -15,8 +15,9 @@ $lambdaRuntimeApi = getenv('AWS_LAMBDA_RUNTIME_API');
 
 require __DIR__ . '/vendor/autoload.php';
 
-$socket = '/tmp/php-cgi.sock';
-$cgi = new Process("php-cgi -b {$socket} -c /opt/php.ini -d extension_dir=/opt/php/extensions");
+$socket = '/tmp/php-fpm.sock';
+$config =  __DIR__ .'/php-fpm.conf';
+$cgi = new Process("php-fpm --fpm-config {$config} -c /opt/php.ini -d extension_dir=/opt/php/extensions");
 $cgi->setTimeout(null);
 $cgi->start(function ($type, $output) {
     if ($type === Process::ERR) {
@@ -25,11 +26,12 @@ $cgi->start(function ($type, $output) {
     }
 });
 
+
 register_shutdown_function(function() use(&$cgi) {
     $cgi->stop();
 });
 
-$wait = 10000; // 10ms
+$wait = 5000; // 5ms
 $timeout = 5000000; // 5 secs
 $elapsed = 0;
 while (! file_exists($socket)) {

--- a/e/symfony/php-fpm.conf
+++ b/e/symfony/php-fpm.conf
@@ -1,0 +1,6 @@
+error_log = /tmp/php-fpm.log
+
+[default]
+pm = static
+pm.max_children = 1
+listen = /tmp/php-fpm.sock

--- a/e/symfony/template.yaml
+++ b/e/symfony/template.yaml
@@ -17,7 +17,7 @@ Resources:
             Handler: index.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416360873395:layer:php-72:3'
+                - 'arn:aws:lambda:us-east-2:416360873395:layer:php-72:4'
             Environment:
                 Variables:
                     APP_ENV: prod


### PR DESCRIPTION
Actually use php-fpm now. Setup is similar but requires a config, which could be placed in the layer like the php.ini, but easier to test this way for now. 
Performance seems similar, perhaps slightly faster. Bootstrap also seems slightly faster (around 180ms or so, but haven't tested extensively).
Anyway, this seems as the preferred method, so this might be better to use.